### PR TITLE
Bugfix: Remove Hardcoded Referenced Versions

### DIFF
--- a/IPIonAWSGovManualIAM.md
+++ b/IPIonAWSGovManualIAM.md
@@ -51,41 +51,43 @@ This guide will assume that the user has valid accounts and subscriptions to bot
 ### Prepare and Deploy
 3. Extract bundle on disconnected vpc host. From the directory containing the OCP bundle.
     ```
-    OCP_VER=$()    
+    OCP_VER=$(ls | grep -oP '(?<=openshift-)\d\.\d\.\d(?=.tar.gz)')    
     tar -xzvf openshift-${OCP_VER}.tar.gz
     ```
 
 4. Create S3 Bucket and attach policies.
 
     ```
+    
     export awsreg=$(aws configure get region)
     export s3name=$(date +%s"-rhcos")
     aws s3api create-bucket --bucket ${s3name} --region ${awsreg} --create-bucket-configuration LocationConstraint=${awsreg}
-    aws iam create-role --role-name vmimport --assume-role-policy-document "file://4.7.0/ocp-disconnected/aws-gov-ipi-dis-maniam/trust-policy.json"
-    envsubst < ./4.7.0/ocp-disconnected/aws-gov-ipi-dis-maniam/role-policy-templ.json > ./4.7.0/ocp-disconnected/aws-gov-ipi-dis-maniam/role-policy.json
-    aws iam put-role-policy --role-name vmimport --policy-name vmimport --policy-document "file://4.7.0/ocp-disconnected/aws-gov-ipi-dis-maniam/role-policy.json"
+    aws iam create-role --role-name vmimport --assume-role-policy-document "file://${OCP_VER}/ocp-disconnected/aws-gov-ipi-dis-maniam/trust-policy.json"
+    envsubst < ./${OCP_VER}/ocp-disconnected/aws-gov-ipi-dis-maniam/role-policy-templ.json > ./${OCP_VER}/ocp-disconnected/aws-gov-ipi-dis-maniam/role-policy.json
+    aws iam put-role-policy --role-name vmimport --policy-name vmimport --policy-document "file://${OCP_VER}/ocp-disconnected/aws-gov-ipi-dis-maniam/role-policy.json"
     ```
 
 5. Upload RHCOS Image to S3
 
     ```
-    gzip -d ./4.7.0/rhcos/rhcos-47.83.202102090044-0-aws.x86_64.vmdk.gz
-    aws s3 mv ./4.7.0/rhcos/rhcos-47.83.202102090044-0-aws.x86_64.vmdk s3://${s3name}
+    export RHCOS_VER=$(ls ./${OCP_VER}/rhcos/ | grep -oP '.*(?=\.vmdk.gz)')
+    gzip -d ./${OCP_VER}/rhcos/${RHCOS_VER}.vmdk.gz
+    aws s3 mv ./${OCP_VER}/rhcos/${RHCOS_VER}.vmdk s3://${s3name}
     ```
 
 6. Create AMI
 
     ```
-    envsubst < ./4.7.0/ocp-disconnected/aws-gov-ipi-dis-maniam/containers-templ.json > ./4.7.0/ocp-disconnected/containers.json
-    taskid=$(aws ec2 import-snapshot --region ${awsreg} --description "rhcos-snapshot" --disk-container file://4.7.0/ocp-disconnected/containers.json | jq -r '.ImportTaskId')
+    envsubst < ./${OCP_VER}/ocp-disconnected/aws-gov-ipi-dis-maniam/containers-templ.json > ./${OCP_VER}/ocp-disconnected/containers.json
+    taskid=$(aws ec2 import-snapshot --region ${awsreg} --description "rhcos-snapshot" --disk-container file://${OCP_VER}/ocp-disconnected/containers.json | jq -r '.ImportTaskId')
     until [[ $resp == "completed" ]]; do sleep 2; echo "Snapshot progress: "$(aws ec2 describe-import-snapshot-tasks --region ${awsreg} | jq --arg task "$taskid" -r '.ImportSnapshotTasks[] | select(.ImportTaskId==$task) | .SnapshotTaskDetail.Progress')"%"; resp=$(aws ec2 describe-import-snapshot-tasks --region ${awsreg} | jq --arg task "$taskid" -r '.ImportSnapshotTasks[] | select(.ImportTaskId==$task) | .SnapshotTaskDetail.Status'); done
     snapid=$(aws ec2 describe-import-snapshot-tasks --region ${awsreg} | jq --arg task "$taskid" '.ImportSnapshotTasks[] | select(.ImportTaskId==$task) | .SnapshotTaskDetail.SnapshotId')
     aws ec2 register-image \
       --region ${awsreg} \
       --architecture x86_64 \
-      --description "rhcos-47.83.202102090044-0-aws.x86_64" \
+      --description "${RHCOS_VER}" \
       --ena-support \
-      --name "rhcos-47.83.202102090044-0-aws.x86_64" \
+      --name "${RHCOS_VER}" \
       --virtualization-type hvm \
       --root-device-name '/dev/xvda' \
       --block-device-mappings 'DeviceName=/dev/xvda,Ebs={DeleteOnTermination=true,SnapshotId='${snapid}'}' 
@@ -101,11 +103,11 @@ This guide will assume that the user has valid accounts and subscriptions to bot
 
 9. Make a copy of the install config
     ```
-    mkdir ./4.7.0/config
-    cp ./4.7.0/ocp-disconnected/aws-gov-ipi-dis-maniam/install-config-template.yaml ./4.7.0/config/install-config.yaml
+    mkdir ./${OCP_VER}/config
+    cp ./${OCP_VER}/ocp-disconnected/aws-gov-ipi-dis-maniam/install-config-template.yaml ./${OCP_VER}/config/install-config.yaml
     ```
 10. Edit install config
-    For this step, Open `./4.7.0/config/install-config.yaml` and edit the following fields:
+    For this step, Open `./${OCP_VER}/config/install-config.yaml` and edit the following fields:
 
     ```
     baseDomain: i.e. example.com
@@ -130,22 +132,22 @@ This guide will assume that the user has valid accounts and subscriptions to bot
 
 11. Make a backup of the final config:
     ```
-    cp -R ./4.7.0/config/ ./4.7.0/config.bak
+    cp -R ./${OCP_VER}/config/ ./${OCP_VER}/config.bak
     ```
 
 12. Create manifests from install config.
     ```
-    openshift-install create manifests --dir ./4.7.0/config
+    openshift-install create manifests --dir ./${OCP_VER}/config
     ```
 
 13. Delete the installer generated secret
     ```
-    rm ./4.7.0/config/openshift/99_cloud-creds-secret.yaml 
+    rm ./${OCP_VER}/config/openshift/99_cloud-creds-secret.yaml 
     ```
 14. create iam users and Policies
 
     ```
-    cd ./4.7.0/ocp-disconnected/aws-gov-ipi-dis-maniam
+    cd ./${OCP_VER}/ocp-disconnected/aws-gov-ipi-dis-maniam
     chmod +x ./ocp-users.sh
     ./ocp-users.sh prepPolicies
     ./ocp-users.sh createUsers
@@ -161,13 +163,13 @@ This guide will assume that the user has valid accounts and subscriptions to bot
 
 16. start up the registry in the background
     ```
-    oc image serve --dir=./4.7.0/release/ --tls-crt=./registry.crt --tls-key=./registry.key &
+    oc image serve --dir=./${OCP_VER}/release/ --tls-crt=./registry.crt --tls-key=./registry.key &
     ```
 
 17. Deploy the cluster
 
     ```
-    openshift-install create cluster --dir ./4.7.0/config
+    openshift-install create cluster --dir ./${OCP_VER}/config
     ```
 #
 ### Cluster Access
@@ -180,7 +182,7 @@ You can now access the cluster via CLI with oc or the web console with a web bro
     ```
     INFO Waiting up to 10m0s for the openshift-console route to be created... 
     INFO Install complete!                            
-    INFO To access the cluster as the system:admin user when using 'oc', run 'export KUBECONFIG=/home/ec2-user/data/vid-pres/4.7.0/config/auth/kubeconfig' 
+    INFO To access the cluster as the system:admin user when using 'oc', run 'export KUBECONFIG=/home/ec2-user/data/vid-pres/${OCP_VER}/config/auth/kubeconfig' 
     INFO Access the OpenShift web-console here: https://console-openshift-console.apps.test-cluster.testocp1.net 
     INFO Login to the console with user: "kubeadmin", and password: "z9yDP-2M6DS-oE9Im-Dcdzk" 
     INFO Time elapsed: 48m34s    

--- a/IPIonAWSGovManualIAM.md
+++ b/IPIonAWSGovManualIAM.md
@@ -28,29 +28,31 @@ This guide will assume that the user has valid accounts and subscriptions to bot
 ## Installing OpenShift 
 
 ### Create OpenShift Installation Bundle
-1. Download and compress the bundle on internet connected machine using the OpenShift4-mirror companion utility found [**here**](https://repo1.dso.mil/platform-one/distros/red-hat/ocp4/openshift4-mirror)
+1. Download and compress the stable release bundle on internet an connected machine using the OpenShift4-mirror companion utility found [**here**](https://repo1.dso.mil/platform-one/distros/red-hat/ocp4/openshift4-mirror)
    
 
    You will first need to retrieve an OpenShift pull secret. Once you have retrieved that, enter it into the literals of the value for `--pull-secret` in the command below. Pull secrets can be obtained from https://cloud.redhat.com/openshift/install/aws/installer-provisioned
 
     ```
+    OCP_VER=$(curl http://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/release.txt 2>&1 | grep -oP "(?<=Version:\s\s).*")
     podman run -it --security-opt label=disable -v ./:/app/bundle quay.io/redhatgov/openshift4_mirror:latest \
       ./openshift_mirror bundle \
-      --openshift-version 4.7.0 \
+      --openshift-version ${OCP_VER} \
       --platform aws \
       --skip-existing \
       --skip-catalogs \
       --pull-secret '{"auths":{"cloud.openshift.com":{"auth":"b3Blb...' && \
-    git clone https://repo1.dso.mil/platform-one/distros/red-hat/ocp4/documentation.git ./4.7.0/ocp-disconnected && \
-    tar -zcvf openshift-4-7-0.tar.gz 4.7.0
+    git clone https://repo1.dso.mil/platform-one/distros/red-hat/ocp4/documentation.git ./${OCP_VER}/ocp-disconnected && \
+    tar -zcvf openshift-${OCP_VER}.tar.gz ${OCP_VER}
     ```
 2. Transfer bundle from internet connected machine to disconnected vpc host.
 
 #
 ### Prepare and Deploy
-3. Extract bundle on disconnected vpc host.
-    ```    
-    tar -xzvf openshift-4-7-0.tar.gz
+3. Extract bundle on disconnected vpc host. From the directory containing the OCP bundle.
+    ```
+    OCP_VER=$()    
+    tar -xzvf openshift-${OCP_VER}.tar.gz
     ```
 
 4. Create S3 Bucket and attach policies.

--- a/aws-gov-ipi-dis-maniam/containers-templ.json
+++ b/aws-gov-ipi-dis-maniam/containers-templ.json
@@ -1,8 +1,8 @@
 {
-   "Description": "rhcos-47.83.202102090044-0-aws.x86_64",
+   "Description": "${RHCOS_VER}",
    "Format": "vmdk",
    "UserBucket": {
       "S3Bucket": "${s3name}",
-      "S3Key": "rhcos-47.83.202102090044-0-aws.x86_64.vmdk"
+      "S3Key": "${RHCOS_VER}.vmdk"
    }
 }

--- a/complianceOperatorInstallation.md
+++ b/complianceOperatorInstallation.md
@@ -1,0 +1,31 @@
+# Disconnected OpenShift Compliance Operator Installation
+
+## Overview
+
+This guide is intended to demonstrate how to install the OpenShift [Compliance Operator](https://github.com/ComplianceAsCode/content) into disconnected OpenShift environments.
+
+The process of installing the OpenShift Compliance Operator can be broke down into three major steps:
+1. Bundling (Internet Connected)
+2. Mirroring (Disconnected)
+3. Installation (Disconnected)
+
+## Bundling
+
+Perform the following steps on an internet connected host.
+
+1. Clone the (unofficial) OpenShift Operator mirroring utility:  
+```
+git clone https://github.com/RedHatGov/openshift-disconnected-operators.git
+```
+2. Retrieve OpenShift Pull Secret from: https://cloud.redhat.com/openshift/install/aws/installer-provisioned
+
+3. Run Compliance Operator convenience bundler:
+```
+cd openshift-disconnected-operators
+./container/container-launch.sh ./bundle.sh '<< Pull Secret>>'
+```
+*Note, ensure pull secret is entered between literals.
+*Note, This process bundles the latest version of operators. Refer to the openshift-disconnected-operators' README for advanced usage.
+
+
+


### PR DESCRIPTION
The govcloud installation doc had several hardcoded references to a static ocp version. Additionally, the RHCOS name for a static ocp version was hardcoded into a template file. Due to the rapid pace of OCP releases, this was not possible to maintain. 

This PR removes all static OCP version references and instead bundles and installs the current stable release of OCP. 

I've done one dry run with the mods and no obvious errors were seen. 